### PR TITLE
Pass correct number of arguments to define-obsolete-...-alias

### DIFF
--- a/volume.el
+++ b/volume.el
@@ -452,7 +452,7 @@ This corresponds to the `-D' option of amixer."
 
 (when (fboundp 'define-obsolete-variable-alias)
   (define-obsolete-variable-alias 'volume-amixer-control
-    'volume-amixer-default-channel))
+    'volume-amixer-default-channel "1.0"))
 
 (defvar volume-amixer-current-channel volume-amixer-default-channel
   "The name of the ALSA mixer channel to manipulate.")
@@ -654,7 +654,7 @@ Return either the new volume or nil, depending on the backend."
 
 (when (fboundp 'define-obsolete-function-alias)
   (define-obsolete-function-alias 'volume-channel-name
-    'volume-channel-label))
+    'volume-channel-label "1.0"))
 
 (defun volume-channels ()
   "Return the list of available channels."


### PR DESCRIPTION
Recent Emacs master branch fails to bytecompile volume.el due to this.